### PR TITLE
Added a new rule the the bosh security group to allow egress traffic …

### DIFF
--- a/bosh-init-tf/resources.tf
+++ b/bosh-init-tf/resources.tf
@@ -14,6 +14,16 @@ resource "openstack_networking_secgroup_v2" "secgroup" {
   description = "BOSH Security Group"
 }
 
+
+resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_7" {
+  region = "${var.region_name}"
+  direction = "egress"
+  ethertype = "IPv4"
+  protocol = "tcp"
+  remote_ip_prefix = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.secgroup.id}"
+}
+
 resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_4" {
   region = "${var.region_name}"
   direction = "ingress"

--- a/bosh-init-tf/resources.tf
+++ b/bosh-init-tf/resources.tf
@@ -14,13 +14,10 @@ resource "openstack_networking_secgroup_v2" "secgroup" {
   description = "BOSH Security Group"
 }
 
-
 resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_7" {
   region = "${var.region_name}"
   direction = "egress"
   ethertype = "IPv4"
-  protocol = "tcp"
-  remote_ip_prefix = "0.0.0.0/0"
   security_group_id = "${openstack_networking_secgroup_v2.secgroup.id}"
 }
 


### PR DESCRIPTION
…so it allow the instance get the metadata server data

Without this security group the instance will be unavailable to get the data from the metadata server and those will not get the ssh-key to allow ingress of the ``bosh-init deploy`` command