### PR TITLE
Rename outputs for reuse

### DIFF
--- a/bosh-init-tf/network-outputs.tf
+++ b/bosh-init-tf/network-outputs.tf
@@ -1,23 +1,23 @@
-output "network CIDR" {
+output "network_cidr" {
   value = "${openstack_networking_subnet_v2.bosh_subnet.cidr}"
 }
 
-output "network gateway IP" {
+output "network_gateway_ip" {
   value = "${openstack_networking_subnet_v2.bosh_subnet.gateway_ip}"
 }
 
-output "network dns" {
+output "network_dns" {
   value = "[${join(",", openstack_networking_subnet_v2.bosh_subnet.dns_nameservers)}]"
 }
 
-output "network id" {
+output "network_id" {
   value = "${openstack_networking_network_v2.bosh.id}"
 }
 
-output "director private ip" {
+output "director_private_ip" {
   value = "${cidrhost(openstack_networking_subnet_v2.bosh_subnet.cidr, 10)}"
 }
 
-output "router id" {
+output "router_id" {
   value = "${openstack_networking_router_v2.bosh_router.id}"
 }

--- a/bosh-init-tf/resources-outputs.tf
+++ b/bosh-init-tf/resources-outputs.tf
@@ -1,7 +1,7 @@
-output "keypair name" {
+output "keypair_name" {
   value = "${openstack_compute_keypair_v2.bosh.name}"
 }
 
-output "allocated floating ip" {
+output "allocated_floating_ip" {
   value = "${openstack_networking_floatingip_v2.bosh.address}"
 }


### PR DESCRIPTION
This removes the spaces in the outputs of bosh-init-tf, making it usable as a module by other TF code.

This will also prevent future breakage when the Terraform team adds planned validation that will cause the code as it stands to throw errors. See https://github.com/hashicorp/terraform/issues/16843