### PR TITLE
Add security_groups to output

### DIFF
--- a/bosh-init-tf/network-outputs.tf
+++ b/bosh-init-tf/network-outputs.tf
@@ -21,3 +21,7 @@ output "internal_ip" {
 output "router_id" {
   value = "${openstack_networking_router_v2.bosh_router.id}"
 }
+
+output "default_security_groups" {
+  value = "[${openstack_networking_secgroup_v2.secgroup.name}]"
+}


### PR DESCRIPTION
http://bosh.io/docs/init-openstack/ will reference the outputs. Since we generate the security_group we should output it's name.