### PR TITLE
Use keypair suffix for security group too

### DIFF
--- a/bosh-init-tf/resources-vars.tf
+++ b/bosh-init-tf/resources-vars.tf
@@ -7,3 +7,8 @@ variable "keypair_suffix" {
 }
 
 
+# security group
+variable "security_group_suffix" {
+  description = "Disambiguate security groups with this suffix"
+  default = ""
+}

--- a/bosh-init-tf/resources.tf
+++ b/bosh-init-tf/resources.tf
@@ -10,7 +10,7 @@ resource "openstack_compute_keypair_v2" "bosh" {
 # security group
 resource "openstack_networking_secgroup_v2" "secgroup" {
   region = "${var.region_name}"
-  name = "bosh"
+  name = "bosh${var.security_group_suffix}"
   description = "BOSH Security Group"
 }
 

--- a/bosh-init-tf/terraform.tfvars.template
+++ b/bosh-init-tf/terraform.tfvars.template
@@ -15,6 +15,9 @@ ext_net_id = "<ext_net_id>"
 # Disambiguate keypairs with this suffix
 # keypair_suffix = "<keypair_suffix>"
 
+# Disambiguate security groups with this suffix
+# security_group_suffix = "<security_group_suffix>"
+
 # in case of self signed certificate select one of the following options
 # cacert_file = "<path-to-certificate>"
 # insecure = "true"


### PR DESCRIPTION
Security groups are referenced by name. Without a suffix we can't install two directors into the same project, because `create-env` will fail.